### PR TITLE
fix: remove node http send result helper

### DIFF
--- a/packages/deno/index.ts
+++ b/packages/deno/index.ts
@@ -4,5 +4,4 @@ export * from "./render-graphiql.ts";
 export * from "./should-render-graphiql.ts";
 export * from "./types.ts";
 export * from "./errors.ts";
-export * from "./send-result/node-http.ts";
 export * from "./send-result/w3c.ts";


### PR DESCRIPTION
This doesn't exist so shouldn't be exported.﻿
