### PR TITLE
Add `onError` option to `processRequest`

### DIFF
--- a/packages/core/lib/process-request.ts
+++ b/packages/core/lib/process-request.ts
@@ -78,6 +78,11 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
     validate = defaultValidate,
     validationRules,
     variables,
+    onError = (error: Error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      return "Internal Server Error";
+    },
   } = options;
 
   let context: TContext | undefined;
@@ -258,7 +263,7 @@ export const processRequest = async <TContext = {}, TRootValue = {}>(
       }
     } catch (error) {
       const payload: ExecutionResult<any> = {
-        errors: ((error as HttpError).graphqlErrors as GraphQLError[]) || [new GraphQLError((error as Error).message)],
+        errors: ((error as HttpError).graphqlErrors as GraphQLError[]) || [new GraphQLError(onError(error as Error))],
       };
 
       if (isEventStream) {

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -131,6 +131,10 @@ export interface ProcessRequestOptions<TContext, TRootValue> {
    * Values for any Variables defined by the Operation.
    */
   variables?: string | { [name: string]: any };
+  /**
+   * An optional function which will be used to format any unexpected errors that occur during execution.
+   */
+  onError?: (error: Error) => string;
 }
 
 export interface FormatPayloadParams<TContext, TRootValue> {


### PR DESCRIPTION
This is just a first pass to get something going. The layers of error catching is a little mysterious to me, perhaps `onError` is too generic of a name for the types of errors that this outer layer is catching. I'm open to ideas.

For #77 

