### PR TITLE
Using graphql-helix instead of ../lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following example shows how to integrate GraphQL Helix with Node.js using Ex
 
 ```js
 import express, { RequestHandler } from "express";
-import { getGraphQLParameters, processRequest, renderGraphiQL, shouldRenderGraphiQL, sendResult } from "../lib";
+import { getGraphQLParameters, processRequest, renderGraphiQL, shouldRenderGraphiQL, sendResult } from "graphql-helix";
 import { schema } from "./schema";
 
 const app = express();


### PR DESCRIPTION
On the Basic Usage example imports 
`import { getGraphQLParameters, processRequest, renderGraphiQL, shouldRenderGraphiQL, sendResult } from "../lib";`

Replacing it with 
`import { getGraphQLParameters, processRequest, renderGraphiQL, sendResult, shouldRenderGraphiQL } from "graphql-helix";`