### PR TITLE
Set content-length header on sendResponseResult

### DIFF
--- a/.changeset/weak-kids-leave.md
+++ b/.changeset/weak-kids-leave.md
@@ -1,0 +1,5 @@
+---
+"graphql-helix": patch
+---
+
+Set content-length header on sendResponseResult

--- a/packages/core/lib/send-result/node-http.ts
+++ b/packages/core/lib/send-result/node-http.ts
@@ -15,10 +15,10 @@ export async function sendResponseResult(
   for (const { name, value } of responseResult.headers) {
     rawResponse.setHeader(name, value);
   }
-  const data = Buffer.from(JSON.stringify(transformResult(responseResult.payload)))
+  const data = JSON.stringify(transformResult(responseResult.payload))
   rawResponse.writeHead(responseResult.status, {
     "content-type": "application/json",
-    "content-length": data.length
+    "content-length": Buffer.byteLength(data, "utf8")
   });
   rawResponse.end(data);
 }

--- a/packages/core/lib/send-result/node-http.ts
+++ b/packages/core/lib/send-result/node-http.ts
@@ -15,10 +15,12 @@ export async function sendResponseResult(
   for (const { name, value } of responseResult.headers) {
     rawResponse.setHeader(name, value);
   }
+  const data = Buffer.from(JSON.stringify(transformResult(responseResult.payload)))
   rawResponse.writeHead(responseResult.status, {
     "content-type": "application/json",
+    "content-length": data.length
   });
-  rawResponse.end(JSON.stringify(transformResult(responseResult.payload)));
+  rawResponse.end(data);
 }
 
 export async function sendMultipartResponseResult(

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -86,6 +86,7 @@ implementations.forEach((implementation) => {
       test("POST basic query", async () => {
         const {
           body: { data, errors },
+          headers,
         } = await post({
           path: "/graphql",
           port,
@@ -97,6 +98,7 @@ implementations.forEach((implementation) => {
         });
         expect(errors).toBeUndefined();
         expect(data?.echo).toBeDefined();
+        expect(headers['content-length']).toBeDefined();
       });
 
       test("POST query with variables", async () => {
@@ -249,6 +251,7 @@ implementations.forEach((implementation) => {
       test("GET basic query", async () => {
         const {
           body: { data, errors },
+          headers,
         } = await get({
           path: "/graphql",
           port,
@@ -260,6 +263,7 @@ implementations.forEach((implementation) => {
         });
         expect(errors).toBeUndefined();
         expect(data?.echo).toBeDefined();
+        expect(headers['content-length']).toBeDefined();
       });
 
       test("GET query with variables", async () => {


### PR DESCRIPTION
We recently changed our API to use graphql-helix and ran into issue that our requests weren't compressed by our CDN. The reason was that response headers didn't include `content-length` when response was coming from graphql-helix. Content-length is set in `sendMultipartResponseResult` but not in `sendResponseResult` function, so I have added code to set headers correctly in `sendResponseResult` function.